### PR TITLE
Se añaden cambios para implementar el dashboard de los finders

### DIFF
--- a/api/controllers/actorController.js
+++ b/api/controllers/actorController.js
@@ -1,6 +1,7 @@
 'use strict'
 /* ---------------ACTOR---------------------- */
 const mongoose = require('mongoose')
+const Finder = require('../models/finder')
 const Actor = mongoose.model('Actors')
 
 exports.list_all_actors = function (req, res) {
@@ -15,11 +16,18 @@ exports.list_all_actors = function (req, res) {
 
 exports.create_an_actor = function (req, res) {
   const newActor = new Actor(req.body)
+  const newFinder = new Finder({'endDate': null, 'keyword': null, 'maxPrice': null, 'minPrice': null, 'startDate': null, 'actor': newActor._id})
   newActor.save(function (err, actor) {
     if (err) {
       res.send(err)
     } else {
-      res.json(actor)
+      newFinder.save(function (err, finder) {
+        if (err) {
+          res.send(err)
+        } else {
+          res.json({actor: actor,finder: finder})
+        }
+      })
     }
   })
 }

--- a/api/controllers/finderController.js
+++ b/api/controllers/finderController.js
@@ -25,7 +25,15 @@ exports.update_a_finder = function (req, res) {
 }
 
 exports.get_dashboard = function (req, res) {
-  
+    Finder.aggregate([[{$facet:{"Top":[{$group:{_id: {keyword: "$keyword"}, count:{$sum:1}}}, {$sort:{count:-1}}, {$group:{_id: "topWords", top_keywords:{$push:"$_id.keyword"}}}, {$project:{_id:0, top_keywords:
+      {$slice:["$top_keywords",10]}}}], "AvgRange": [{$group: {_id:"dashboard" ,avgPriceRangeLow:{$avg:"$minPrice"},avgPriceRangeHigh:{$avg:"$maxPrice"}}},{$project: {_id:0}}]}},
+{$project: {"data": {$concatArrays: ["$Top","$AvgRange"]}}}]], function (err, dashboard) {
+      if (err) {
+        console.log(err)
+        res.send(err)
+      } else {
+        res.json(dashboard[0].data)
+      }})
 }
 
 exports.update_config = function (req, res){

--- a/api/routes/finderRoutes.js
+++ b/api/routes/finderRoutes.js
@@ -1,13 +1,13 @@
 'use strict'
 module.exports = function (app) {
   const finders = require('../controllers/finderController');
+  
+  app.route('/finders/dashboard')
+    .get(finders.get_dashboard) //finder dashboard
 
   app.route('/finders/:finderId')
     .get(finders.read_a_finder) 
     .put(finders.update_a_finder) //manage finder (update)
-
-  app.route('/finders/dashboard')
-    .get(finders.get_dashboard) //finder dashboard
   
   app.route('/finders/config/:configId')
   .put(finders.update_config) // update cached period, update limit results


### PR DESCRIPTION
Para ello se ha implementado la creación de los finder asociandola a la creación del usuario propietario del finder, se ha cambiado el orden de las rutas porque si no tomaba la palabra "dashboard" como id y se ha implementado la consulta necesaria en mongo.